### PR TITLE
Update links to new repo location

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/rosen-score/lila-gitpod:main
+image: ghcr.io/lichess-org/lila-gitpod:main
 
 tasks:
   - name: lila

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a s
 - Seed your database with test data
 - Start lila
 
-Read the full [Lichess on Gitpod documentation](https://rosen-score.github.io/lila-gitpod/).
+Read the full [Lichess on Gitpod documentation](https://lichess-org.github.io/lila-gitpod/).
 
-Click here to create a workspace: [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rosen-score/lila-gitpod)
+Click here to create a workspace: [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/lichess-org/lila-gitpod)
 
 ![lila-on-gitpod](https://user-images.githubusercontent.com/271432/183785811-dc00e385-f13f-4226-9654-93b6465c75cb.png)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 Click here to start a workspace:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rosen-score/lila-gitpod)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/lichess-org/lila-gitpod)
 
 It will take about 8-10 minutes. You can watch the progress in the 3 terminal windows that automatically open.
 

--- a/gitpod/Welcome.md
+++ b/gitpod/Welcome.md
@@ -12,4 +12,4 @@ It will take about 8-10 minutes.
 
 Open a new terminal ("+" icon) and type `gp ports list`. When port 9663 says "open", click the link next to it to go to your dev site.
 
-For test logins and other notes, see https://rosen-score.github.io/lila-gitpod/
+For test logins and other notes, see https://lichess-org.github.io/lila-gitpod/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: lila-gitpod
 
-repo_url: https://github.com/rosen-score/lila-gitpod/
+repo_url: https://github.com/lichess-org/lila-gitpod/
 edit_uri: blob/main/docs/
 
 nav:


### PR DESCRIPTION
- [x] Change repo description link to https://lichess-org.github.io/lila-gitpod/
- [x] Create repository env secret value for Github action to publish the base Docker image to the Github registry

Creating the access token:
1) https://github.com/settings/tokens
2) Generate new token with scope: `write:packages`
3) Add the value as a secret named `TOKEN` here: https://github.com/lichess-org/lila-gitpod/settings/secrets/actions