### PR TITLE
Nginx proxy for lila + lila-ws to share same subdomain

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,15 +28,15 @@ tasks:
       ## Create config for lila
       cp /workspace/lila/conf/application.conf.default /workspace/lila/conf/application.conf
       tee -a /workspace/lila/conf/application.conf <<EOF
-      net.domain = "$(gp url 9663 | cut -c9-)"
-      net.socket.domains = [ "$(gp url 9664 | cut -c9-)" ]
-      net.base_url = "$(gp url 9663)"
-      net.asset.base_url = "$(gp url 9663)"
+      net.domain = "$(gp url 8080 | cut -c9-)"
+      net.socket.domains = [ "$(gp url 8080 | cut -c9-)" ]
+      net.base_url = "$(gp url 8080)"
+      net.asset.base_url = "$(gp url 8080)"
       EOF
       ## Create config for lila-ws (websockets)
       tee /workspace/lila-ws-gitpod-application.conf <<EOF
       include "application"
-      csrf.origin = "$(gp url 9663)"
+      csrf.origin = "$(gp url 8080)"
       EOF
       ## Create config for fishnet clients
       tee /workspace/fishnet/fishnet.ini <<EOF
@@ -56,8 +56,11 @@ tasks:
       cd /workspace/lila && ./ui/build
 
 ports:
+  - port: 8080
+    name: lichess
   - port: 9663
     name: lila
+    onOpen: ignore
   - port: 9664
     name: lila-ws
     onOpen: ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN sudo apt-get autoremove -y \
   && sudo apt-get clean
 
 # Add nginx site config
-COPY build/nginx/lichess.conf /etc/nginx/sites-enabled
+COPY build/nginx/lichess.conf /etc/nginx/sites-enabled/
 
 RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod
 USER gitpod

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,14 @@ RUN wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key 
 RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
 RUN sudo apt-get update && sudo apt update \
-  && sudo apt-get install -y git-all golang-go mongodb-org parallel psmisc python3.9 python3-pip redis-server unzip vim zip
+  && sudo apt-get install -y git-all golang-go mongodb-org nginx parallel psmisc python3.9 python3-pip redis-server unzip vim zip
 
 # Cleanup
 RUN sudo apt-get autoremove -y \
   && sudo apt-get clean
+
+# Add nginx site config
+COPY build/nginx/lichess.conf /etc/nginx/sites-enabled
 
 RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod
 USER gitpod

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN sudo apt-get autoremove -y \
 
 # Add nginx site config
 COPY build/nginx/lichess.conf /etc/nginx/sites-enabled/
+RUN rm /etc/nginx/sites-enabled/default
 
 RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod
 USER gitpod

--- a/build/nginx/lichess.conf
+++ b/build/nginx/lichess.conf
@@ -5,6 +5,7 @@ server {
     listen       8080;
     server_name  lichess;
 
+    # lila-ws (websocket) traffic
     location ~ /(v5|v6)$ {
         proxy_pass http://0.0.0.0:9664;
 
@@ -13,6 +14,7 @@ server {
         proxy_set_header Connection "upgrade";
     }
 
+    # lila traffic
     location / {
         proxy_pass http://0.0.0.0:9663;
 

--- a/build/nginx/lichess.conf
+++ b/build/nginx/lichess.conf
@@ -1,0 +1,21 @@
+# Nginx is used to proxy lila and lila-ws traffic through the same port
+# so they can be run on the same subdomain to share cookies
+
+server {
+    listen       8080;
+    server_name  lichess;
+
+    location ~ /(v5|v6)$ {
+        proxy_pass http://0.0.0.0:9664;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location / {
+        proxy_pass http://0.0.0.0:9663;
+
+        include /etc/nginx/proxy_params;
+    }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ It will take about 8-10 minutes. You can watch the progress in the 3 terminal wi
 
 To get the URL for your development site, in a new terminal, type:
 
-    gp url 9663
+    gp url 8080
 
 Once lila is running, your dev site will be available. You can check the status of the ports with:
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -2,9 +2,9 @@
 
 ## Making your development site public
 
-By default, your Lichess dev site is only accessible by you. If you want to make it available to others or if you're developing an API client application, you can make ports `9663` and `9664` public.
+By default, your Lichess dev site is only accessible by you. If you want to make it available to others or if you're developing an API client application, you can make port `8080` public.
 
-Click the Remote Explorer icon on the left menu column, then change the port visibility to public for `9663` and `9664`.
+Click the Remote Explorer icon on the left menu column, then change the port visibility to public for `8080`. You can keep the others private.
 
 !!! attention
 

--- a/gitpod/Welcome.md
+++ b/gitpod/Welcome.md
@@ -12,4 +12,4 @@ It will take about 8-10 minutes.
 
 Open a new terminal ("+" icon) and type `gp ports list`. When port 9663 says "open", click the link next to port 8080 to open your development site.
 
-For test logins and other notes, see https://lichess-org.github.io/lila-gitpod/
+For test logins and more documentation, see https://lichess-org.github.io/lila-gitpod/

--- a/gitpod/Welcome.md
+++ b/gitpod/Welcome.md
@@ -10,6 +10,6 @@ You can watch the progress in the 3 terminal tabs that are running below:
 
 It will take about 8-10 minutes.
 
-Open a new terminal ("+" icon) and type `gp ports list`. When port 9663 says "open", click the link next to it to go to your dev site.
+Open a new terminal ("+" icon) and type `gp ports list`. When port 9663 says "open", click the link next to port 8080 to open your development site.
 
 For test logins and other notes, see https://lichess-org.github.io/lila-gitpod/


### PR DESCRIPTION
Necessary to share the `lila2` cookie, otherwise lila-ws sees the request as unauthenticated