### PR TITLE
Add proxy_http_version 1.1 in nginx config for streaming responses

### DIFF
--- a/build/nginx/lichess.conf
+++ b/build/nginx/lichess.conf
@@ -11,6 +11,7 @@ server {
 
     # lila-ws (websocket) traffic
     location @websocket {
+        proxy_http_version 1.1;
         proxy_pass http://0.0.0.0:9664;
 
         proxy_http_version 1.1;
@@ -20,6 +21,7 @@ server {
 
     # lila traffic
     location @ {
+        proxy_http_version 1.1;
         proxy_pass http://0.0.0.0:9663;
 
         include /etc/nginx/proxy_params;


### PR DESCRIPTION
Was getting an error when (while logged in as admin) on a user profile page clicking the Mod icon.

```
play.api.http.HttpErrorHandlerExceptions$$anon$1:
Execution exception[[ServerResultException: HTTP 1.0 client does not support chunked response]]
```

Upgrading proxy to version 1.1 as mentioned in [Play Framework docs](https://www.playframework.com/documentation/2.3.x/ScalaStream)