### PR TITLE
Remove theme from .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "gitpod.experimental.portsView.enabled": true,
-  "workbench.colorTheme": "Visual Studio Dark",
   "workbench.editorAssociations": {
     "Welcome.md": "vscode.markdown.preview.editor"
   }


### PR DESCRIPTION
Don't think there's really a reason or point to forcing this theme on people? Also doesn't really work anymore once VSCode is reopened with lila.